### PR TITLE
Make Fortran AMO type tables consistent/correct

### DIFF
--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -43,8 +43,8 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
  }
 
 \apidesctable{
-    When using \Fortran, \VAR{dest} must be of the following type:
-}{Routine}{Data type of \VAR{dest}}
+    When using \Fortran, \VAR{dest} and \VAR{value} must be of the following type:
+}{Routine}{Data type of \VAR{dest} and \VAR{value}}
 
 \apitablerow{SHMEM\_INT4\_ADD}{\CONST{4}-byte integer}
 \apitablerow{SHMEM\_INT8\_ADD}{\CONST{8}-byte integer}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -46,8 +46,7 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
     atomic operation.
 }
 \apidesctable{
-    The  \VAR{dest} and \VAR{value} data objects must conform to certain typing
-    constraints, which are as follows:
+    When using \Fortran, \VAR{dest} and \VAR{value} must be of the following type:
 }{Routine}{Data type of \VAR{dest} and \VAR{value}}
 
 \apitablerow{SHMEM\_INT4\_CSWAP}{\CONST{4}-byte integer.}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -46,8 +46,8 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
     atomic operation.
 }
 \apidesctable{
-    When using \Fortran, \VAR{dest} and \VAR{value} must be of the following type:
-}{Routine}{Data type of \VAR{dest} and \VAR{value}}
+    When using \Fortran, \VAR{dest}, \VAR{cond}, and \VAR{value} must be of the following type:
+}{Routine}{Data type of \VAR{dest}, \VAR{cond}, and \VAR{value}}
 
 \apitablerow{SHMEM\_INT4\_CSWAP}{\CONST{4}-byte integer.}
 \apitablerow{SHMEM\_INT8\_CSWAP}{\CONST{8}-byte integer.}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -47,8 +47,8 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 }
 
 \apidesctable{
-    When using \Fortran, \VAR{dest} must be of the following type:
-}{Routine}{Data type of \VAR{dest} and \VAR{source}}
+    When using \Fortran, \VAR{dest} and \VAR{value} must be of the following type:
+}{Routine}{Data type of \VAR{dest} and \VAR{value}}
 
 \apitablerow{SHMEM\_INT4\_FADD}{\CONST{4}-byte integer}
 \apitablerow{SHMEM\_INT8\_FADD}{\CONST{8}-byte integer}

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -45,7 +45,7 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
 
 \apidesctable{
     When using \Fortran, \VAR{dest} must be of the following type:
-}{Routine}{Data type of \VAR{dest} and \VAR{source}}
+}{Routine}{Data type of \VAR{dest}}
 
 \apitablerow{SHMEM\_INT4\_FINC}{\CONST{4}-byte integer}
 \apitablerow{SHMEM\_INT8\_FINC}{\CONST{8}-byte integer}

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -41,7 +41,7 @@ CALL SHMEM_INT8_INC(dest, pe)
 
 \apidesctable{
     When using \Fortran, \VAR{dest} must be of the following type:
-}{Routine}{Data type of \VAR{dest} and \VAR{source}}
+}{Routine}{Data type of \VAR{dest}}
 
 \apitablerow{SHMEM\_INT4\_INC}{\CONST{4}-byte integer}
 \apitablerow{SHMEM\_INT8\_INC}{\CONST{8}-byte integer}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -45,8 +45,8 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 }
 
 \apidesctable{
-    When using \Fortran, \VAR{dest} must be of the following type:
-}{Routine}{Data type of \VAR{dest} and \VAR{source}}
+  When using \Fortran, \VAR{dest} and \VAR{value} must be of the following type:
+}{Routine}{Data type of \VAR{dest} and \VAR{value}}
 
 \apitablerow{SHMEM\_SWAP}{Integer of default kind}
 \apitablerow{SHMEM\_INT4\_SWAP}{\CONST{4}-byte integer}


### PR DESCRIPTION
These are just minor issues with the Fortran descriptions, but might as well fix them while we're at it.