### PR TITLE
Section/rma amo/consist params

### DIFF
--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -25,7 +25,7 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{OUT}{dest}{The remotely accessible integer data object to be
+    \apiargument{IN}{dest}{The remotely accessible integer data object to be
         updated  on the remote \ac{PE}.  When using \CorCpp, the type of
         \dest{} should match that implied in the SYNOPSIS section.}
     \apiargument{IN}{value}{The value to be atomically added to \dest. When using \CorCpp, the type of \VAR{value} should match that  implied  in

--- a/content/shmem_atomic_and.tex
+++ b/content/shmem_atomic_and.tex
@@ -19,7 +19,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
+  \apiargument{IN}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.}
   \apiargument{IN}{pe}{An integer value for the \ac{PE} on which \VAR{dest}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -25,7 +25,7 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{OUT}{dest}{The remotely accessible integer data object to be
+    \apiargument{IN}{dest}{The remotely accessible integer data object to be
         updated on the remote \ac{PE}. }
     \apiargument{IN}{cond}{\VAR{cond} is compared to the remote \VAR{dest}
         value. If \VAR{cond} and the remote \VAR{dest} are equal, then \VAR{value}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -26,7 +26,7 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 
 \begin{apiarguments}
 
-\apiargument{OUT}{dest}{The remotely accessible integer data object to be updated on
+\apiargument{IN}{dest}{The remotely accessible integer data object to be updated on
     the remote \ac{PE}. The type of \VAR{dest} should match that implied in the
     SYNOPSIS section.}
 \apiargument{IN}{value}{The value to be atomically added to \VAR{dest}.  The

--- a/content/shmem_atomic_fetch_and.tex
+++ b/content/shmem_atomic_fetch_and.tex
@@ -18,7 +18,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
+  \apiargument{IN}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise AND operation.}
   \apiargument{IN}{pe}{An integer value for the \ac{PE} on which \VAR{dest}

--- a/content/shmem_atomic_fetch_or.tex
+++ b/content/shmem_atomic_fetch_or.tex
@@ -18,7 +18,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
+  \apiargument{IN}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.}
   \apiargument{IN}{pe}{An integer value for the \ac{PE} on which \VAR{dest}

--- a/content/shmem_atomic_fetch_xor.tex
+++ b/content/shmem_atomic_fetch_xor.tex
@@ -19,7 +19,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
+  \apiargument{IN}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.}
   \apiargument{IN}{pe}{An integer value for the \ac{PE} on which \VAR{dest}

--- a/content/shmem_atomic_or.tex
+++ b/content/shmem_atomic_or.tex
@@ -19,7 +19,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
+  \apiargument{IN}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise OR operation.}
   \apiargument{IN}{pe}{An integer value for the \ac{PE} on which \VAR{dest}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -28,7 +28,7 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{OUT}{dest}{The  remotely accessible integer data object to be
+    \apiargument{IN}{dest}{The  remotely accessible integer data object to be
         updated on the remote \ac{PE}.	 When using \CorCpp, the type of
         \dest{} should match that  implied in the SYNOPSIS section.}
     \apiargument{IN}{value}{The value to be atomically written to the remote

--- a/content/shmem_atomic_xor.tex
+++ b/content/shmem_atomic_xor.tex
@@ -19,7 +19,7 @@ where \TYPE{} is one of the bitwise \ac{AMO} types and has a corresponding
 
 \begin{apiarguments}
 
-  \apiargument{OUT}{dest}{A pointer to the remotely accessible data object to
+  \apiargument{IN}{dest}{A pointer to the remotely accessible data object to
     be updated.}
   \apiargument{IN}{value}{The operand to the bitwise XOR operation.}
   \apiargument{IN}{pe}{An integer value for the \ac{PE} on which \VAR{dest}

--- a/content/shmem_g.tex
+++ b/content/shmem_g.tex
@@ -5,18 +5,18 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-TYPE shmem_g(const TYPE *addr, int pe);
+TYPE shmem_g(const TYPE *source, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the standard \ac{RMA} types specified by Table \ref{stdrmatypes}.
 
 \begin{Csynopsis}
-TYPE shmem_<TYPENAME>_g(const TYPE *addr, int pe);
+TYPE shmem_<TYPENAME>_g(const TYPE *source, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{apiarguments}
-    \apiargument{IN}{addr}{The remotely accessible array element or scalar data object.}
-    \apiargument{IN}{pe}{The number of the remote \ac{PE} on which \VAR{addr} resides.}
+    \apiargument{IN}{source}{The remotely accessible array element or scalar data object.}
+    \apiargument{IN}{pe}{The number of the remote \ac{PE} on which \VAR{source} resides.}
 \end{apiarguments}
 
 \apidescription{

--- a/content/shmem_iput.tex
+++ b/content/shmem_iput.tex
@@ -34,7 +34,7 @@ CALL SHMEM_REAL_IPUT(dest, source, dst, sst, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{OUT}{dest}{Array to be updated on the remote \ac{PE}. This data
+    \apiargument{IN}{dest}{Array to be updated on the remote \ac{PE}. This data
         object  must be remotely accessible.}
     \apiargument{IN}{source}{Array containing the data to be copied.}
     \apiargument{IN}{dst}{The stride between consecutive elements of the \dest{}

--- a/content/shmem_p.tex
+++ b/content/shmem_p.tex
@@ -15,9 +15,9 @@ void shmem_<TYPENAME>_p(TYPE *dest, TYPE value, int pe);
 where \TYPE{} is one of the standard \ac{RMA} types and has a corresponding \TYPENAME{} specified by Table \ref{stdrmatypes}.
 
 \begin{apiarguments}
-    \apiargument{IN}{addr}{The remotely accessible array element or scalar data object
+    \apiargument{IN}{dest}{The remotely accessible array element or scalar data object
     which will receive the data on the remote \ac{PE}.}
-    \apiargument{IN}{value}{The value to be transferred to \VAR{addr} on the
+    \apiargument{IN}{value}{The value to be transferred to \VAR{dest} on the
     remote \ac{PE}.}
     \apiargument{IN}{pe}{The number of the remote \ac{PE}.}
 \end{apiarguments}

--- a/content/shmem_put.tex
+++ b/content/shmem_put.tex
@@ -42,7 +42,7 @@ CALL SHMEM_REAL_PUT(dest, source, nelems, pe)
 \begin{apiarguments}
     \apiargument{IN}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
-    \apiargument{OUT}{source}{Data object containing the data to be copied.}
+    \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}
     arrays. \VAR{nelems} must be of type \VAR{size\_t} for \Cstd. When using
     \Fortran, it must be a constant, variable, or array element of default

--- a/content/shmem_put_nbi.tex
+++ b/content/shmem_put_nbi.tex
@@ -40,7 +40,7 @@ CALL SHMEM_REAL_PUT_NBI(dest, source, nelems, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
-    \apiargument{OUT}{dest}{Data object to be updated on the remote \ac{PE}. This
+    \apiargument{IN}{dest}{Data object to be updated on the remote \ac{PE}. This
     data object must be remotely accessible.}
     \apiargument{IN}{source}{Data object containing the data to be copied.}
     \apiargument{IN}{nelems}{Number of elements in the \VAR{dest} and \VAR{source}


### PR DESCRIPTION
This PR tries to fix two consistency issues in the RMA/AMO sections.
1. IN/OUT attribution.
2. Argument naming for dest/source objects.