### PR TITLE
Clarify the AMO notes on the deprecated old-style interfaces

### DIFF
--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -18,6 +18,19 @@ void shmem_ctx_<TYPENAME>_atomic_add(shmem_ctx_t ctx, TYPE *dest, TYPE value, in
 where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+void shmem_add(TYPE *dest, TYPE value, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+void shmem_<TYPENAME>_add(TYPE *dest, TYPE value, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}
+and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4  value_i4
@@ -59,14 +72,7 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_add} and \FUNC{shmem\_TYPENAME\_add} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_add} and
-    \FUNC{shmem\_TYPENAME\_atomic\_add}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
-    types.
+    None.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_add.tex
+++ b/content/shmem_atomic_add.tex
@@ -59,9 +59,14 @@ CALL SHMEM_INT8_ADD(dest, value_i8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_add} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_add}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_add} and \FUNC{shmem\_TYPENAME\_add} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_add} and
+    \FUNC{shmem\_TYPENAME\_atomic\_add}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
+    types.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -65,9 +65,14 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_cswap} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_compare\_swap}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_cswap} and \FUNC{shmem\_TYPENAME\_cswap} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_compare\_swap} and
+    \FUNC{shmem\_TYPENAME\_atomic\_compare\_swap}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
+    types.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_compare_swap.tex
+++ b/content/shmem_atomic_compare_swap.tex
@@ -18,6 +18,19 @@ TYPE shmem_ctx_<TYPENAME>_atomic_compare_swap(shmem_ctx_t ctx, TYPE *dest, TYPE 
 where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+TYPE shmem_cswap(TYPE *dest, TYPE cond, TYPE value, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+TYPE shmem_<TYPENAME>_cswap(TYPE *dest, TYPE cond, TYPE value, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}
+and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4 SHMEM_INT4_CSWAP,  cond_i4, value_i4, ires_i4
@@ -65,14 +78,7 @@ ires_i8 = SHMEM_INT8_CSWAP(dest, cond_i8, value_i8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_cswap} and \FUNC{shmem\_TYPENAME\_cswap} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_compare\_swap} and
-    \FUNC{shmem\_TYPENAME\_atomic\_compare\_swap}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
-    types.
+    None.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -5,28 +5,28 @@
 \begin{apidefinition}
 
 \begin{C11synopsis}
-TYPE shmem_atomic_fetch(const TYPE *dest, int pe);
-TYPE shmem_atomic_fetch(shmem_ctx_t ctx, const TYPE *dest, int pe);
+TYPE shmem_atomic_fetch(const TYPE *source, int pe);
+TYPE shmem_atomic_fetch(shmem_ctx_t ctx, const TYPE *source, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of the extended \ac{AMO} types specified by
 Table~\ref{extamotypes}.
 
 \begin{Csynopsis}
-TYPE shmem_<TYPENAME>_atomic_fetch(const TYPE *dest, int pe);
-TYPE shmem_ctx_<TYPENAME>_atomic_fetch(shmem_ctx_t ctx, const TYPE *dest, int pe);
+TYPE shmem_<TYPENAME>_atomic_fetch(const TYPE *source, int pe);
+TYPE shmem_ctx_<TYPENAME>_atomic_fetch(shmem_ctx_t ctx, const TYPE *source, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{extamotypes}.
 
 \begin{DeprecateBlock}
 \begin{C11synopsis}
-TYPE shmem_fetch(const TYPE *dest, int pe);
+TYPE shmem_fetch(const TYPE *source, int pe);
 \end{C11synopsis}
 where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
 \CTYPE{long}, \CTYPE{long long}\}.
 
 \begin{Csynopsis}
-TYPE shmem_<TYPENAME>_fetch(const TYPE *dest, int pe);
+TYPE shmem_<TYPENAME>_fetch(const TYPE *source, int pe);
 \end{Csynopsis}
 where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
 \CTYPE{long}, \CTYPE{long long}\} and has a corresponding
@@ -36,13 +36,13 @@ where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4 SHMEM_INT4_FETCH, ires_i4
-ires_i4 = SHMEM_INT4_FETCH(dest, pe)
+ires_i4 = SHMEM_INT4_FETCH(source, pe)
 INTEGER*8 SHMEM_INT8_FETCH, ires_i8
-ires_i8 = SHMEM_INT8_FETCH(dest, pe)
+ires_i8 = SHMEM_INT8_FETCH(source, pe)
 REAL*4 SHMEM_REAL4_FETCH, res_r4
-res_r4 = SHMEM_REAL4_FETCH(dest, pe)
+res_r4 = SHMEM_REAL4_FETCH(source, pe)
 REAL*8 SHMEM_REAL8_FETCH, res_r8
-res_r8 = SHMEM_REAL8_FETCH(dest, pe)
+res_r8 = SHMEM_REAL8_FETCH(source, pe)
 \end{Fsynopsis}
 
 \begin{apiarguments}
@@ -50,20 +50,20 @@ res_r8 = SHMEM_REAL8_FETCH(dest, pe)
   \apiargument{IN}{ctx}{The context on which to perform the operation.
     When this argument is not provided, the operation is performed on
     \CONST{SHMEM\_CTX\_DEFAULT}.}
-  \apiargument{IN}{dest}{The remotely accessible data object to be fetched from
+  \apiargument{IN}{source}{The remotely accessible data object to be fetched from
     the remote \ac{PE}.}
   \apiargument{IN}{pe}{An integer that indicates the \ac{PE} number from which
-    \VAR{dest} is to be fetched.}
+    \VAR{source} is to be fetched.}
 
 \end{apiarguments}
 
 \apidescription{
     \FUNC{shmem\_atomic\_fetch} performs an atomic fetch operation.
-    It returns the contents of the \VAR{dest} as an atomic operation.
+    It returns the contents of the \VAR{source} as an atomic operation.
 }
 
 \apireturnvalues{
-    The contents at the \VAR{dest} address on the remote \ac{PE}.
+    The contents at the \VAR{source} address on the remote \ac{PE}.
     The data type of the return value is the same as the type of
     the remote data object.
 }

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -18,6 +18,21 @@ TYPE shmem_ctx_<TYPENAME>_atomic_fetch(shmem_ctx_t ctx, const TYPE *dest, int pe
 where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{extamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+TYPE shmem_fetch(const TYPE *dest, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+\CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+TYPE shmem_<TYPENAME>_fetch(const TYPE *dest, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+\CTYPE{long}, \CTYPE{long long}\} and has a corresponding
+\TYPENAME{} specified by Table~\ref{extamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4 SHMEM_INT4_FETCH, ires_i4
@@ -54,14 +69,7 @@ res_r8 = SHMEM_REAL8_FETCH(dest, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_fetch} and \FUNC{shmem\_TYPENAME\_fetch} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_fetch} and
-    \FUNC{shmem\_TYPENAME\_atomic\_fetch}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{float}, \CTYPE{double}, \CTYPE{int},
-    \CTYPE{long}, and \CTYPE{long~long} types.
+    None.
 }
 
 \end{apidefinition}

--- a/content/shmem_atomic_fetch.tex
+++ b/content/shmem_atomic_fetch.tex
@@ -54,9 +54,14 @@ res_r8 = SHMEM_REAL8_FETCH(dest, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_fetch} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_fetch}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_fetch} and \FUNC{shmem\_TYPENAME\_fetch} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_fetch} and
+    \FUNC{shmem\_TYPENAME\_atomic\_fetch}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+    \CTYPE{long}, and \CTYPE{long~long} types.
 }
 
 \end{apidefinition}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -18,6 +18,19 @@ TYPE shmem_ctx_<TYPENAME>_atomic_fetch_add(shmem_ctx_t ctx, TYPE *dest, TYPE val
 where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+TYPE shmem_fadd(TYPE *dest, TYPE value, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+TYPE shmem_<TYPENAME>_fadd(TYPE *dest, TYPE value, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}
+and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4 SHMEM_INT4_FADD, ires_i4, value_i4
@@ -66,14 +79,7 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_fetch\_add} and \FUNC{shmem\_TYPENAME\_fetch\_add} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_fetch\_add} and
-    \FUNC{shmem\_TYPENAME\_atomic\_fetch\_add}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
-    types.
+    None.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_fetch_add.tex
+++ b/content/shmem_atomic_fetch_add.tex
@@ -66,9 +66,14 @@ ires_i8 = SHMEM_INT8_FADD(dest, value_i8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_fadd} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_fetch\_add}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_fetch\_add} and \FUNC{shmem\_TYPENAME\_fetch\_add} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_fetch\_add} and
+    \FUNC{shmem\_TYPENAME\_atomic\_fetch\_add}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
+    types.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -18,6 +18,19 @@ TYPE shmem_ctx_<TYPENAME>_atomic_fetch_inc(shmem_ctx_t ctx, TYPE *dest, int pe);
 where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+TYPE shmem_finc(TYPE *dest, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+TYPE shmem_<TYPENAME>_finc(TYPE *dest, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}
+and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4 SHMEM_INT4_FINC, ires_i4
@@ -61,14 +74,7 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_fetch\_inc} and \FUNC{shmem\_TYPENAME\_fetch\_inc} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_fetch\_inc} and
-    \FUNC{shmem\_TYPENAME\_atomic\_fetch\_inc}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
-    types.
+    None.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_fetch_inc.tex
+++ b/content/shmem_atomic_fetch_inc.tex
@@ -61,9 +61,14 @@ ires_i8 = SHMEM_INT8_FINC(dest, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_finc} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_fetch\_inc}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_fetch\_inc} and \FUNC{shmem\_TYPENAME\_fetch\_inc} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_fetch\_inc} and
+    \FUNC{shmem\_TYPENAME\_atomic\_fetch\_inc}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
+    types.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -18,6 +18,19 @@ void shmem_ctx_<TYPENAME>_atomic_inc(shmem_ctx_t ctx, TYPE *dest, int pe);
 where \TYPE{} is one of the standard \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{stdamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+void shmem_inc(TYPE *dest, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+void shmem_<TYPENAME>_inc(TYPE *dest, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{int}, \CTYPE{long}, \CTYPE{long long}\}
+and has a corresponding \TYPENAME{} specified by Table~\ref{stdamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 CALL SHMEM_INT4_INC(dest, pe)
@@ -56,14 +69,7 @@ CALL SHMEM_INT8_INC(dest, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_inc} and \FUNC{shmem\_TYPENAME\_inc} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_inc} and
-    \FUNC{shmem\_TYPENAME\_atomic\_inc}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
-    types.
+    None.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_inc.tex
+++ b/content/shmem_atomic_inc.tex
@@ -56,9 +56,14 @@ CALL SHMEM_INT8_INC(dest, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_inc} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_inc}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_inc} and \FUNC{shmem\_TYPENAME\_inc} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_inc} and
+    \FUNC{shmem\_TYPENAME\_atomic\_inc}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{int}, \CTYPE{long}, and \CTYPE{long~long}
+    types.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -53,9 +53,14 @@ CALL SHMEM_REAL8_SET(dest, value_r8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_set} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_set}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_set} and \FUNC{shmem\_TYPENAME\_set} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_set} and
+    \FUNC{shmem\_TYPENAME\_atomic\_set}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+    \CTYPE{long}, and \CTYPE{long~long} types.
 }
 
 \end{apidefinition}

--- a/content/shmem_atomic_set.tex
+++ b/content/shmem_atomic_set.tex
@@ -18,6 +18,21 @@ void shmem_ctx_<TYPENAME>_atomic_set(shmem_ctx_t ctx, TYPE *dest, TYPE value, in
 where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding
 \TYPENAME{} specified by Table~\ref{extamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+void shmem_set(TYPE *dest, TYPE value, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+\CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+void shmem_<TYPENAME>_set(TYPE *dest, TYPE value, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+\CTYPE{long}, \CTYPE{long long}\} and has a corresponding
+\TYPENAME{} specified by Table~\ref{extamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER pe
 INTEGER*4 SHMEM_INT4_SET, value_i4
@@ -53,14 +68,7 @@ CALL SHMEM_REAL8_SET(dest, value_r8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_set} and \FUNC{shmem\_TYPENAME\_set} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_set} and
-    \FUNC{shmem\_TYPENAME\_atomic\_set}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{float}, \CTYPE{double}, \CTYPE{int},
-    \CTYPE{long}, and \CTYPE{long~long} types.
+    None.
 }
 
 \end{apidefinition}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -65,9 +65,14 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], \FUNC{shmem\_swap} has been deprecated.
-    Its behavior and call signature are identical to the replacement
-    interface, \FUNC{shmem\_atomic\_swap}.
+    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
+    \FUNC{shmem\_swap} and \FUNC{shmem\_TYPENAME\_swap} have been
+    deprecated. Their behavior and call signature are identical to the
+    respective replacement interfaces, \FUNC{shmem\_atomic\_swap} and
+    \FUNC{shmem\_TYPENAME\_atomic\_swap}, subject to the constraints
+    that the deprecated interfaces do not accept a context argument and
+    are only supported for \CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+    \CTYPE{long}, and \CTYPE{long~long} types.
 }
 
 \begin{apiexamples}

--- a/content/shmem_atomic_swap.tex
+++ b/content/shmem_atomic_swap.tex
@@ -16,6 +16,21 @@ TYPE shmem_ctx_<TYPENAME>_atomic_swap(shmem_ctx_t ctx, TYPE *dest, TYPE value, i
 \end{Csynopsis}
 where \TYPE{} is one of the extended \ac{AMO} types and has a corresponding \TYPENAME{} specified by Table \ref{extamotypes}.
 
+\begin{DeprecateBlock}
+\begin{C11synopsis}
+TYPE shmem_swap(TYPE *dest, TYPE value, int pe);
+\end{C11synopsis}
+where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+\CTYPE{long}, \CTYPE{long long}\}.
+
+\begin{Csynopsis}
+TYPE shmem_<TYPENAME>_swap(TYPE *dest, TYPE value, int pe);
+\end{Csynopsis}
+where \TYPE{} is one of \{\CTYPE{float}, \CTYPE{double}, \CTYPE{int},
+\CTYPE{long}, \CTYPE{long long}\} and has a corresponding
+\TYPENAME{} specified by Table~\ref{extamotypes}.
+\end{DeprecateBlock}
+
 \begin{Fsynopsis}
 INTEGER SHMEM_SWAP, value, pe
 ires = SHMEM_SWAP(dest, value, pe)
@@ -65,14 +80,7 @@ res_r8 = SHMEM_REAL8_SWAP(dest, value_r8, pe)
 }
 
 \apinotes{
-    As of \openshmem[1.4], the \Cstd[11] and \CorCpp interfaces
-    \FUNC{shmem\_swap} and \FUNC{shmem\_TYPENAME\_swap} have been
-    deprecated. Their behavior and call signature are identical to the
-    respective replacement interfaces, \FUNC{shmem\_atomic\_swap} and
-    \FUNC{shmem\_TYPENAME\_atomic\_swap}, subject to the constraints
-    that the deprecated interfaces do not accept a context argument and
-    are only supported for \CTYPE{float}, \CTYPE{double}, \CTYPE{int},
-    \CTYPE{long}, and \CTYPE{long~long} types.
+    None.
 }
 
 \begin{apiexamples}


### PR DESCRIPTION
These changes (attempt to) address https://github.com/openshmem-org/specification/issues/185

Pinging @BryantLam