### PR TITLE
Add size_t and ptrdiff_t to reduction types

### DIFF
--- a/content/shmem_reductions.tex
+++ b/content/shmem_reductions.tex
@@ -181,6 +181,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
       int                & int        &              & MAX, MIN & SUM, PROD \\ \hline
       long               & long       &              & MAX, MIN & SUM, PROD \\ \hline
       long long          & longlong   &              & MAX, MIN & SUM, PROD \\ \hline
+      ptrdiff\_t         & ptrdiff    &              & MAX, MIN & SUM, PROD \\ \hline
       unsigned char      & uchar      & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
       unsigned short     & ushort     & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
       unsigned int       & uint       & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
@@ -194,6 +195,7 @@ where \TYPE{} is one of the integer, real, or complex types supported for the PR
       uint16\_t          & uint16     & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
       uint32\_t          & uint32     & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
       uint64\_t          & uint64     & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
+      size\_t            & size       & AND, OR, XOR & MAX, MIN & SUM, PROD \\ \hline
       float              & float      &              & MAX, MIN & SUM, PROD \\ \hline
       double             & double     &              & MAX, MIN & SUM, PROD \\ \hline
       long double        & longdouble &              & MAX, MIN & SUM, PROD \\ \hline


### PR DESCRIPTION
Adds `size_t` and `ptrdiff_t` to reduction types; these were missed in cc8e90b