### PR TITLE
Clarify element sizes for collectives

### DIFF
--- a/content/shmem_alltoall.tex
+++ b/content/shmem_alltoall.tex
@@ -41,7 +41,12 @@ void @\FuncDecl{shmem\_alltoall64}@(void *dest, const void *source, size_t nelem
     elements of data for each \ac{PE} in the active set, ordered according to
     destination \ac{PE}.
     The type of \source{} should match that implied in the SYNOPSIS section.}
-    \apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.}
+\apiargument{IN}{nelems}{
+  The number of elements to exchange for each \ac{PE}.
+  For \FUNC{shmem\_alltoallmem}, elements are bytes;
+  for \FUNC{shmem\_alltoall\{32,64\}}, elements are 4 or 8 bytes,
+  respectively.
+}
 
 \begin{DeprecateBlock}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of

--- a/content/shmem_alltoalls.tex
+++ b/content/shmem_alltoalls.tex
@@ -47,9 +47,14 @@ void @\FuncDecl{shmem\_alltoalls64}@(void *dest, const void *source, ptrdiff_t d
 \apiargument{IN}{sst}{The  stride between consecutive elements of the
     \source{} data object.  The stride is scaled by the element size.
     A value of \CONST{1} indicates contiguous data.}
+\apiargument{IN}{nelems}{
+  The number of elements to exchange for each \ac{PE}.
+  For \FUNC{shmem\_alltoallsmem}, elements are bytes;
+  for \FUNC{shmem\_alltoalls\{32,64\}}, elements are 4 or 8 bytes,
+  respectively.
+}
     
 \begin{DeprecateBlock}
-\apiargument{IN}{nelems}{The number of elements to exchange for each \ac{PE}.}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of
     \acp{PE}.}
 \apiargument{IN}{logPE\_stride}{The log (base 2) of the stride between

--- a/content/shmem_broadcast.tex
+++ b/content/shmem_broadcast.tex
@@ -38,7 +38,12 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
       The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{source}{Symmetric address of the source data object.
       The type of \source{} should match that implied in the SYNOPSIS section.}
-    \apiargument{IN}{nelems}{The number of elements in \source.}
+\apiargument{IN}{nelems}{
+  The number of elements in \source{} and \dest{} arrays.
+  For \FUNC{shmem\_broadcastmem}, elements are bytes;
+  for \FUNC{shmem\_broadcast\{32,64\}}, elements are 4 or 8 bytes,
+  respectively.
+}
 \apiargument{IN}{PE\_root}{Zero-based ordinal of the \ac{PE}, with respect to
     the team or active set, from which the data is copied.}
 
@@ -64,7 +69,6 @@ void @\FuncDecl{shmem\_broadcast64}@(void *dest, const void *source, size_t nele
     The same \dest{} and \source{} data objects and the same value of
     \VAR{PE\_root} must be passed by all \acp{PE} participating in the
     collective operation.
-
 
     For team-based broadcasts:
     \begin{itemize}

--- a/content/shmem_collect.tex
+++ b/content/shmem_collect.tex
@@ -43,7 +43,12 @@ void @\FuncDecl{shmem\_fcollect64}@(void *dest, const void *source, size_t nelem
     The type of \dest{} should match that implied in the SYNOPSIS section.}
 \apiargument{IN}{source}{Symmetric address of the source data object.
     The type of \source{} should match that implied in the SYNOPSIS section.}
-\apiargument{IN}{nelems}{The number of elements in the \source{} array.}
+\apiargument{IN}{nelems}{
+  The number of elements in \source{} array.
+  For \FUNC{shmem\_[f]collectmem}, elements are bytes;
+  for \FUNC{shmem\_[f]collect\{32,64\}}, elements are 4 or 8 bytes,
+  respectively.
+}
 
 \begin{DeprecateBlock}
 \apiargument{IN}{PE\_start}{The lowest \ac{PE} number of the active set of


### PR DESCRIPTION
- Applies to shmem_{broadcast, [f]collect, alltoall[s]}
- Specifies nelems == bytes for shmem_*mem
- Specifies nelems == {4,8}\*bytes for shmem_\*{32,64}
- Fixes "deprecation" of nelems argument in alltoalls

Closes openshmem-org/specification/issues/376