### PR TITLE
Reorder collectives

### DIFF
--- a/main_spec.tex
+++ b/main_spec.tex
@@ -399,6 +399,12 @@ signal operator.
 \subsubsection{\textbf{SHMEM\_SYNC\_ALL}}\label{subsec:shmem_sync_all}
 \input{content/shmem_sync_all.tex}
 
+\subsubsection{\textbf{SHMEM\_ALLTOALL}}\label{subsec:shmem_alltoall}
+\input{content/shmem_alltoall.tex}
+
+\subsubsection{\textbf{SHMEM\_ALLTOALLS}}\label{subsec:shmem_alltoalls}
+\input{content/shmem_alltoalls.tex}
+
 \subsubsection{\textbf{SHMEM\_BROADCAST}}\label{subsec:shmem_broadcast}
 \input{content/shmem_broadcast.tex}
 
@@ -407,12 +413,6 @@ signal operator.
 
 \subsubsection{\textbf{SHMEM\_REDUCTIONS}}\label{subsec:shmem_reductions}
 \input{content/shmem_reductions.tex}
-
-\subsubsection{\textbf{SHMEM\_ALLTOALL}}\label{subsec:shmem_alltoall}
-\input{content/shmem_alltoall.tex}
-
-\subsubsection{\textbf{SHMEM\_ALLTOALLS}}\label{subsec:shmem_alltoalls}
-\input{content/shmem_alltoalls.tex}
 
 
 


### PR DESCRIPTION
Make the order of collective pseudo-alphabetical;
`shmem_alltoall[s]` is now before `shmem_broadcast`.

Closes openshmem-org/specification/issues/383