### PR TITLE
Clarify list of routines in collective_intro

### DIFF
--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -48,12 +48,12 @@ The team-based collective routines defined in the \openshmem Specification are:
 
 \begin{itemize}
 \item \FUNC{shmem\_team\_sync}
+\item \FUNC{shmem\_\{TYPE\_\}alltoall\{mem\}}
+\item \FUNC{shmem\_\{TYPE\_\}alltoalls\{mem\}}
 \item \FUNC{shmem\_\{TYPE\_\}broadcast\{mem\}}
 \item \FUNC{shmem\_\{TYPE\_\}collect\{mem\}}
 \item \FUNC{shmem\_\{TYPE\_\}fcollect\{mem\}}
 \item Reduction routines for the following operations: AND, OR, XOR, MAX, MIN, SUM, PROD
-\item \FUNC{shmem\_\{TYPE\_\}alltoall\{mem\}}
-\item \FUNC{shmem\_\{TYPE\_\}alltoalls\{mem\}}
 \end{itemize}
 
 In addition, all team creation functions are collective operations. In addition to the ordering
@@ -105,12 +105,12 @@ routines defined in the \openshmem Specification are:
 \begin{itemize}
 \item \FUNC{shmem\_barrier}
 \item \FUNC{shmem\_sync}
+\item \FUNC{shmem\_alltoall\{32, 64\}}
+\item \FUNC{shmem\_alltoalls\{32, 64\}}
 \item \FUNC{shmem\_broadcast\{32, 64\}}
 \item \FUNC{shmem\_collect\{32, 64\}}
 \item \FUNC{shmem\_fcollect\{32, 64\}}
 \item Reduction routines for the following operations: AND, OR, XOR, MAX, MIN, SUM, PROD
-\item \FUNC{shmem\_alltoall\{32, 64\}}
-\item \FUNC{shmem\_alltoalls\{32, 64\}}
 \end{itemize}
 
 \end{DeprecateBlock}

--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -48,12 +48,12 @@ The team-based collective routines defined in the \openshmem Specification are:
 
 \begin{itemize}
 \item \FUNC{shmem\_team\_sync}
-\item \FUNC{shmem\_\{TYPE\_\}alltoall\{mem\}}
-\item \FUNC{shmem\_\{TYPE\_\}alltoalls\{mem\}}
-\item \FUNC{shmem\_\{TYPE\_\}broadcast\{mem\}}
-\item \FUNC{shmem\_\{TYPE\_\}collect\{mem\}}
-\item \FUNC{shmem\_\{TYPE\_\}fcollect\{mem\}}
-\item Reduction routines for the following operations: AND, OR, XOR, MAX, MIN, SUM, PROD
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]alltoall[mem]}
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]alltoalls[mem]}
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]broadcast[mem]}
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]collect[mem]}
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]fcollect[mem]}
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]\{and, or, xor, max, min, sum, prod\}\_reduce}
 \end{itemize}
 
 In addition, all team creation functions are collective operations. In addition to the ordering
@@ -110,7 +110,7 @@ routines defined in the \openshmem Specification are:
 \item \FUNC{shmem\_broadcast\{32, 64\}}
 \item \FUNC{shmem\_collect\{32, 64\}}
 \item \FUNC{shmem\_fcollect\{32, 64\}}
-\item Reduction routines for the following operations: AND, OR, XOR, MAX, MIN, SUM, PROD
+\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]\{and, or, xor, max, min, sum, prod\}\_to\_all}
 \end{itemize}
 
 \end{DeprecateBlock}

--- a/content/collective_intro.tex
+++ b/content/collective_intro.tex
@@ -110,7 +110,7 @@ routines defined in the \openshmem Specification are:
 \item \FUNC{shmem\_broadcast\{32, 64\}}
 \item \FUNC{shmem\_collect\{32, 64\}}
 \item \FUNC{shmem\_fcollect\{32, 64\}}
-\item \FUNC{shmem\_[\FuncParam{TYPENAME}\_]\{and, or, xor, max, min, sum, prod\}\_to\_all}
+\item \FUNC{shmem\_\FuncParam{TYPENAME}\_\{and, or, xor, max, min, sum, prod\}\_to\_all}
 \end{itemize}
 
 \end{DeprecateBlock}


### PR DESCRIPTION
- Make this list match the collectives section order from `main_spec.tex`; i.e., move alltoall routines to the top of the list.
- Use `\FuncParam{TYPENAME}` instead of `TYPE`
- Precisely specified the reduction routines in the active-set-based and team-based list
- Use `[ ... ]` for optionals and `{ ... }` for sets
