### PR TITLE
Remove teams changelog from section/collectives

### DIFF
--- a/content/backmatter.tex
+++ b/content/backmatter.tex
@@ -522,23 +522,6 @@ The following list describes the specific changes in \openshmem[1.5]:
 \CONST{SHMEM\_MALLOC\_ATOMICS\_REMOTE} and \CONST{SHMEM\_MALLOC\_SIGNAL\_REMOTE}.
 \\ See Section \ref{subsec:shmmallochint} and \ref{subsec:library_constants}.
 %
-\item Specified that team-based broadcast operations update the \VAR{dest} object on
-all \acp{PE}, including the root \ac{PE}.
-\\ See Section \ref{subsec:shmem_broadcast}.
-%
-\item Deprecated active-set-based collective functions.
-\\ See Section \ref{subsec:coll}.
-%
-\item Added team-based collective functions: \FUNC{shmem\_sync},
-  \FUNC{shmem\_broadcast\{mem\}}, \FUNC{shmem\_collect\{mem\}},\\
-  \FUNC{shmem\_TYPENAME\_OP\_reduce},
-  \FUNC{shmem\_alltoall\{mem\}}, and
-  \FUNC{shmem\_alltoalls\{mem\}}.
-  \\ See Sections \ref{subsec:shmem_sync},
-  \ref{subsec:shmem_broadcast}, \ref{subsec:shmem_collect},
-  \ref{subsec:shmem_reductions}, \ref{subsec:shmem_alltoall},
-  and \ref{subsec:shmem_alltoalls}.
-%
 \item Added support for nonblocking \ac{AMO} functions.
 \\ See Section \ref{sec:amo-nbi}.
 %


### PR DESCRIPTION
Merge conflict between:
- https://github.com/BryantLam/openshmem-specification/pull/12
- https://github.com/BryantLam/openshmem-specification/pull/13
- https://github.com/nspark/specification/pull/10

This entry will be deleted from `nspark:section/collectives` and moved into `BryantLam:sec/backmatter`:
- https://github.com/BryantLam/openshmem-specification/pull/16 (Please help review this PR!)

This PR effects the deletion from the Collectives section.